### PR TITLE
Add footnotes and partial ref fixes

### DIFF
--- a/scripts/overrides/tei_to_html.xsl
+++ b/scripts/overrides/tei_to_html.xsl
@@ -98,9 +98,8 @@
     </ul>
   </xsl:variable>
 
-
-  <!-- notes -->  
-    <xsl:template match="text//ref">
+  <!-- <ref>s footnotes -->  
+    <xsl:template match="text//ref[@target]">
       <xsl:choose>
         <xsl:when test="@n">
           <a>
@@ -117,14 +116,97 @@
             </sup>
         </a>
         </xsl:when>
-      <!-- display non-linked, non-footnote <ref>s like * and † in anc.00065 -->
+      <!-- make sure non-linked, non-footnote <ref>s like * and † in anc.00065 are still displayed -->
         <xsl:otherwise>
           <xsl:apply-templates />
         </xsl:otherwise>
       </xsl:choose>
         
     </xsl:template>
-    
+
+    <!-- / <ref>s footnotes -->
+
+    <!-- don't display duplicated <div1 type="notes"> -->
+      <xsl:template match="//div1[@type='notes']">
+      </xsl:template>
+    <!-- / don't display -->
+
+  <!-- note -->
+  <xsl:template match="note">
+    <xsl:choose>
+      <xsl:when test="@place='foot'">
+        <span>
+          <xsl:attribute name="class">
+            <xsl:call-template name="add_attributes"/>
+            <xsl:text>foot </xsl:text>
+          </xsl:attribute>
+          <xsl:if test="@xml:id">
+            <xsl:attribute name="id" select="@xml:id"/>
+          </xsl:if>
+          <a>
+            <xsl:attribute name="href">
+              <xsl:text>#</xsl:text>
+              <xsl:text>foot</xsl:text>
+              <xsl:value-of select="@xml:id"/>
+            </xsl:attribute>
+            <xsl:attribute name="id">
+              <xsl:text>body</xsl:text>
+              <xsl:value-of select="@xml:id"/>
+            </xsl:attribute>
+
+            <xsl:text>(</xsl:text>
+            <xsl:value-of select="substring(@xml:id, 2)"/>
+            <xsl:text>)</xsl:text>
+          </a>
+        </span>
+      </xsl:when>
+
+      <!-- resp wwa from legacy_xslt -->
+      <xsl:when test="@resp='wwa'">
+        <span>
+          <sup xmlns="http://www.w3.org/1999/xhtml">
+            <a>
+              <xsl:attribute name="href">
+                <xsl:text>#</xsl:text>
+                <xsl:value-of select="@xml:id"/>
+            </xsl:attribute>
+            <xsl:attribute name="id">
+              <xsl:text>r</xsl:text>
+              <xsl:number count="note[@resp='wwa']" level="any"/></xsl:attribute>
+              <xsl:number count="note[@resp='wwa']" level="any"/>
+            </a>
+          </sup>
+        </span>
+      </xsl:when>
+      <!-- /resp wwa -->
+
+      <!-- rep unk from legacy_xslt -->
+      <xsl:when test="@resp='unk'">
+        <p>
+        <xsl:apply-templates/></p>
+      </xsl:when>
+      <!-- / resp unk -->
+
+      <xsl:otherwise>
+        <span>
+          <xsl:attribute name="class">
+            <xsl:call-template name="add_attributes"/><xsl:text> </xsl:text>
+            <xsl:value-of select="name()"/>
+          </xsl:attribute>
+          <xsl:if test="@xml:id">
+            <xsl:attribute name="id" select="@xml:id"/>
+          </xsl:if>
+          <span>
+            <xsl:apply-templates/>
+            <xsl:text> </xsl:text>
+          </span>
+        </span>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+
+   <!-- move notes to end of doc -->
     <xsl:template match="text">
       <xsl:apply-templates/>
       <xsl:if test="//note[@type='editorial'] or //note[@type='authorial']">
@@ -141,11 +223,11 @@
               <xsl:apply-templates/>
               <xsl:text> [</xsl:text>
               <a>
-                  <xsl:attribute name="href">
-                      <xsl:text>#ref_</xsl:text>
-                      <xsl:value-of select="@target"/>
-                  </xsl:attribute>
-                  <xsl:text>back</xsl:text>
+                <xsl:attribute name="href">
+                    <xsl:text>#ref_</xsl:text>
+                    <xsl:value-of select="@target"/>
+                </xsl:attribute>
+                <xsl:text>back</xsl:text>
               </a>
               <xsl:text>]</xsl:text>
             </p>
@@ -156,12 +238,7 @@
         </div>
       </xsl:if>
     </xsl:template>
-
-    <!-- don't display div1 notes as if it's part of the text -->
-    <xsl:template match="//div1[@type='notes']">
-    </xsl:template>
-
-    <!-- / notes -->
+  <!-- / move notes -->
 
 
   <!-- sic and corr -->

--- a/scripts/overrides/tei_to_html.xsl
+++ b/scripts/overrides/tei_to_html.xsl
@@ -24,6 +24,18 @@
   <!-- For display in TEI framework, have changed all namespace declarations to http://www.tei-c.org/ns/1.0. If different (e.g. Whitman), will need to change -->
   <xsl:output method="xml" indent="no" encoding="UTF-8" omit-xml-declaration="no"/>
   
+  <!-- consider moving to overrides.xsl -->
+  <xsl:template match="hi[@rend='superscript']">
+    <sup>
+      <xsl:attribute name="class">
+        <xsl:value-of select="@rend"/>
+        <xsl:text> </xsl:text>
+        <xsl:call-template name="add_attributes"/>
+      </xsl:attribute>
+      <xsl:apply-templates/>
+    </sup>
+  </xsl:template>
+  
   <!-- add overrides for this section here -->
   
   <xsl:variable name="top_metadata">
@@ -85,6 +97,83 @@
         </li>
     </ul>
   </xsl:variable>
+
+
+  <!-- notes -->  
+    <xsl:template match="text//ref">
+      <xsl:choose>
+        <xsl:when test="@n">
+          <a>
+            <xsl:attribute name="href">
+                <xsl:text>#</xsl:text>
+                <xsl:value-of select="@target"/>
+            </xsl:attribute>
+            <sup class="footnote_sup_link">
+                <xsl:attribute name="id">
+                    <xsl:text>ref_</xsl:text>
+                    <xsl:value-of select="@xml:id"/>
+                </xsl:attribute>
+                <xsl:value-of select="@n"/>
+            </sup>
+        </a>
+        </xsl:when>
+      <!-- display non-linked, non-footnote <ref>s like * and † in anc.00065 -->
+        <xsl:otherwise>
+          <xsl:apply-templates />
+        </xsl:otherwise>
+      </xsl:choose>
+        
+    </xsl:template>
+    
+    <xsl:template match="text">
+      <xsl:apply-templates/>
+      <xsl:if test="//note[@type='editorial'] or //note[@type='authorial']">
+        <hr />
+        <div class="notes">
+          <h3 span="notes_title">Notes</h3>
+          <xsl:for-each select="//text//note">
+            <p>
+              <xsl:attribute name="id">
+                  <xsl:value-of select="@xml:id"/>
+              </xsl:attribute>
+              <xsl:value-of select="count(preceding::note[ancestor::text]) +1"/>
+              <xsl:text>. </xsl:text>
+              <xsl:apply-templates/>
+              <xsl:text> [</xsl:text>
+              <a>
+                  <xsl:attribute name="href">
+                      <xsl:text>#ref_</xsl:text>
+                      <xsl:value-of select="@target"/>
+                  </xsl:attribute>
+                  <xsl:text>back</xsl:text>
+              </a>
+              <xsl:text>]</xsl:text>
+            </p>
+                <xsl:text>
+          
+        </xsl:text>
+          </xsl:for-each>
+        </div>
+      </xsl:if>
+    </xsl:template>
+
+    <!-- don't display div1 notes as if it's part of the text -->
+    <xsl:template match="//div1[@type='notes']">
+    </xsl:template>
+
+    <!-- / notes -->
+
+
+  <!-- sic and corr -->
+  <!-- overriding because (in anc.00062 at least) sic is shown and corr is hidden -->
+  <xsl:template match="choice[child::sic]">
+    <span class="tei_choice">
+      <span class="tei_sic tei_sic_no_strikethrough">
+        <xsl:value-of select="sic"/>&#8203;
+      </span>
+    </span>
+  </xsl:template>
+<!-- / sic and corr -->
 
 
 


### PR DESCRIPTION
Adds footnotes (we missed this repo on our first pass!)
Takes into account places where `<ref>` is used for an authorial note instead of `<note>`, but there are discrepancies that will need to be addressed at some point, likely in the TEI; I will make an issue.